### PR TITLE
AMP-28065 Issue IATI: Currency code usd could not be found in AMP

### DIFF
--- a/import-core/import-services/src/main/java/org/devgateway/importtool/services/processor/AMPStaticProcessor.java
+++ b/import-core/import-services/src/main/java/org/devgateway/importtool/services/processor/AMPStaticProcessor.java
@@ -878,7 +878,7 @@ public class AMPStaticProcessor implements IDestinationProcessor {
 		}).findFirst().get();
 
 		Optional<FieldValue> foundCurrency = currency.getPossibleValues().stream().filter(n -> {
-			return n.getValue().equals(currencyCode);
+			return n.getValue().equalsIgnoreCase(currencyCode);
 		}).findFirst();
 
 		FieldValue currencyValue;


### PR DESCRIPTION
AMP-28065 Issue IATI: Currency code usd could not be found in AMP